### PR TITLE
refactor: remove api route group

### DIFF
--- a/apps/client/app/components/cookie-form.tsx
+++ b/apps/client/app/components/cookie-form.tsx
@@ -34,7 +34,7 @@ export default function CookieForm() {
                             parseStringToJSON(localStorage);
 
                         const response = await fetch(
-                            `${process.env.NEXT_PUBLIC_API_URL}/api/d2l/credentials`,
+                            `${process.env.NEXT_PUBLIC_API_URL}/d2l/credentials`,
                             {
                                 method: 'POST',
                                 headers: {

--- a/apps/client/app/dev/files/page.tsx
+++ b/apps/client/app/dev/files/page.tsx
@@ -27,7 +27,7 @@ export default function DevPage() {
                         const formData = new FormData(e.currentTarget);
 
                         const res = await fetch(
-                            `${process.env.NEXT_PUBLIC_API_URL}/api/dev/assignment-files`,
+                            `${process.env.NEXT_PUBLIC_API_URL}/dev/assignment-files`,
                             {
                                 method: 'POST',
                                 body: formData,

--- a/apps/server/cmd/main.go
+++ b/apps/server/cmd/main.go
@@ -31,7 +31,7 @@ func main() {
 	config.AllowOrigins = []string{os.Getenv("FRONTEND_URL")}
 	router.Use(cors.New(config))
 
-	api := router.Group("/api")
+	api := router.Group("/")
 	{
 		routes.RegisterD2LRoutes(api)
 		routes.RegisterDevRoutes(api)


### PR DESCRIPTION
## What Changed

Removed `/api` prefix from API endpoint URLs by updating the server route group from `/api` to `/` and adjusting client-side fetch calls to match the new endpoint structure.

## Why This Change

Simplifies the API routing structure by eliminating the redundant `/api` prefix, making endpoints more direct and reducing URL complexity.

## Test Plan

- [ ] Verify cookie form submission works with new `/d2l/credentials` endpoint
- [ ] Test file upload functionality on dev page using `/dev/assignment-files` endpoint
- [ ] Confirm all existing API calls function correctly without `/api` prefix
- [ ] Validate CORS configuration still works with updated route group

## Steps to Deploy

- [ ] IF DEPLOYING TO MAIN, REBASE FROM MAIN
- [ ] Update any hardcoded API URLs in configuration or documentation
- [ ] Verify frontend environment variables point to correct base URL

## Type of Change

- [x] `refactor:` Code refactoring

## Security & Quality Checklist

- [x] No secrets or API keys committed (ghp\_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)