### PR TITLE
feat(agent): claude service

### DIFF
--- a/apps/server/cmd/main.go
+++ b/apps/server/cmd/main.go
@@ -41,4 +41,5 @@ func main() {
 	fmt.Println("Starting server on port " + port + "...")
 
 	router.Run(":" + port)
+
 }

--- a/apps/server/internal/handlers/dev/get-claude-response.go
+++ b/apps/server/internal/handlers/dev/get-claude-response.go
@@ -1,0 +1,33 @@
+package dev
+
+import (
+	"net/http"
+	"server/internal/services"
+
+	"github.com/gin-gonic/gin"
+)
+
+func GetClaudeResponse(c *gin.Context) {
+	claudeService, err := services.New()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	response, err := claudeService.Run(c.Request.Context(), services.ClaudeServiceConfig{
+		Model: "claude-sonnet-4-6",
+		MaxTokens: 10000,
+		Messages: []services.AnthropicMessage{
+			{
+				Role: services.AnthropicRoleUser,
+				Message: "What is the capital of France?",
+			},
+		},
+	})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"response": response})
+}

--- a/apps/server/internal/routes/dev.go
+++ b/apps/server/internal/routes/dev.go
@@ -10,6 +10,7 @@ func RegisterDevRoutes(rg *gin.RouterGroup) {
 	routes := rg.Group("/dev")
 	{
 		routes.POST("/assignment-files", dev.SaveAssignmentFiles)
+		routes.POST("/claude", dev.GetClaudeResponse)
 		// routes.POST("/complete-assignment", dev.CompleteAssignment)
 		routes.POST("/update-content", dev.UpdateContent)
 	}

--- a/apps/server/internal/services/claude.go
+++ b/apps/server/internal/services/claude.go
@@ -1,0 +1,124 @@
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"os"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+)
+type ClaudeService struct {
+	Client *anthropic.Client
+}
+
+type AnthropicMessageRole string
+
+const (
+	AnthropicRoleUser      AnthropicMessageRole = "user"
+	AnthropicRoleAssistant AnthropicMessageRole = "assistant"
+)
+
+type AnthropicMessage struct {
+	Role    AnthropicMessageRole
+	Message string
+}
+
+
+type ClaudeServiceConfig struct {
+	Model     anthropic.Model
+	MaxTokens int64
+	Messages  []AnthropicMessage
+	Tools     *[]anthropic.BetaToolUnionParam
+	Betas     *[]anthropic.AnthropicBeta
+	Skills    *[]anthropic.BetaSkillParams
+}
+
+
+func newClient() (*anthropic.Client, error) {
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+
+	if apiKey == "" {
+		return nil, fmt.Errorf("ANTHROPIC_API_KEY is not set")
+	}
+
+	client := anthropic.NewClient(
+		option.WithAPIKey(apiKey), 
+	)
+
+	return &client, nil
+}
+
+
+
+func New() (*ClaudeService, error){
+	client, err := newClient()
+
+	if err != nil {
+		return nil, fmt.Errorf(err.Error())
+	}
+
+	return &ClaudeService{
+		client,
+	}, nil
+}
+
+func (claudeService *ClaudeService) Run(ctx context.Context, config ClaudeServiceConfig) (*anthropic.BetaMessage, error) {
+	messages, err := parseMessagesParam(config.Messages)
+	if err != nil {
+		return nil, err
+	}
+
+	params := anthropic.BetaMessageNewParams{
+		Model:     config.Model,
+		MaxTokens: config.MaxTokens,
+		Messages:  messages,
+	}
+
+	if config.Skills != nil {
+		params.Container = anthropic.BetaMessageNewParamsContainerUnion{
+			OfContainers: &anthropic.BetaContainerParams{
+				Skills: *config.Skills,
+			},
+		}
+	}
+
+	if config.Tools != nil {
+		params.Tools = *config.Tools
+	}
+	if config.Betas != nil {
+		params.Betas = *config.Betas
+	}
+
+	response, err := claudeService.Client.Beta.Messages.New(ctx, params)
+
+	if err != nil {
+		return nil, fmt.Errorf(fmt.Sprintf("Error getting Claude response: %s", err.Error()))
+	}
+
+	return response, nil
+}
+
+func parseMessagesParam(messages []AnthropicMessage) ([]anthropic.BetaMessageParam, error) {
+	res := make([]anthropic.BetaMessageParam, 0, len(messages))
+
+	for _, m := range messages {
+		switch m.Role {
+		case AnthropicRoleUser:
+			res = append(res, anthropic.BetaMessageParam{
+				Role:    anthropic.BetaMessageParamRoleUser,
+				Content: []anthropic.BetaContentBlockParamUnion{anthropic.NewBetaTextBlock(m.Message)},
+			})
+		case AnthropicRoleAssistant:
+			res = append(res, anthropic.BetaMessageParam{
+				Role:    anthropic.BetaMessageParamRoleAssistant,
+				Content: []anthropic.BetaContentBlockParamUnion{anthropic.NewBetaTextBlock(m.Message)},
+			})
+		default:
+			return nil, fmt.Errorf("unknown message role: %q", m.Role)
+		}
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
## What Changed

Added Claude AI integration to the server with a new service layer and development endpoint. Created a `ClaudeService` that wraps the Anthropic SDK, providing configurable message handling with support for different models, token limits, tools, and skills. Added a `/dev/claude` POST endpoint that demonstrates the integration by asking "What is the capital of France?" using the claude-sonnet-4-6 model.

## Why This Change

This establishes the foundation for AI-powered features in the application by integrating Claude AI capabilities. The service layer provides a clean abstraction over the Anthropic SDK, making it easy to configure and use Claude for various AI tasks throughout the application.

## Test Plan

- [ ] Verify `ANTHROPIC_API_KEY` environment variable is set
- [ ] Test POST request to `/dev/claude` endpoint returns successful response