### PR TITLE
fix: auto-create test-bucket in MinIO on startup

### DIFF
--- a/apps/server/internal/storage/config.go
+++ b/apps/server/internal/storage/config.go
@@ -12,6 +12,10 @@ import (
 	awsconfig "github.com/aws/smithy-go"
 )
 
+// DefaultBucketName is the bucket ensured on startup and used throughout the
+// app. Kept as a constant so it can be swapped later (e.g. per-env or per-org).
+const DefaultBucketName = "test-bucket"
+
 var S3BasicsBucket BucketBasics
 
 func ConnectObjectStorage() {
@@ -80,4 +84,27 @@ func ConnectObjectStorage() {
 
 		fmt.Printf("Listed %v buckets successfully\n", count)
 	}
+
+	ensureDefaultBucket(ctx)
+}
+
+// ensureDefaultBucket makes sure DefaultBucketName exists so downstream code
+// paths (uploads, presigned URLs) don't fail on a fresh MinIO volume. Any
+// failure is logged but does not abort startup.
+func ensureDefaultBucket(ctx context.Context) {
+	exists, err := S3BasicsBucket.BucketExists(ctx, DefaultBucketName)
+	if err != nil {
+		fmt.Printf("Failed to check if bucket %q exists: %v\n", DefaultBucketName, err)
+		return
+	}
+	if exists {
+		fmt.Printf("Bucket %q already exists, skipping creation.\n", DefaultBucketName)
+		return
+	}
+	region := os.Getenv("AWS_REGION")
+	if err := S3BasicsBucket.CreateBucket(ctx, DefaultBucketName, region); err != nil {
+		fmt.Printf("Failed to create bucket %q in region %q: %v\n", DefaultBucketName, region, err)
+		return
+	}
+	fmt.Printf("Created bucket %q in region %q.\n", DefaultBucketName, region)
 }


### PR DESCRIPTION
## What Changed

Auto-create test bucket if not exists

<!-- Describe the specific changes made in this PR -->

## Why This Change

Avoid error if test-bucket does not exist

<!-- Explain the motivation and context for this change -->

## Test Plan

- [ ] Provide a test plan in the form of a checklist
- [ ] Consider different cases and describe the flows e.g
- [ ] Create account using stripe webhook

## Steps to Deploy

- [ ] IF DEPLOYING TO MAIN, REBASE FROM MAIN
- [ ] Include migrations
- [ ] Include scripts to be run
- [ ] Include manual setup that needs to be done

## Type of Change

- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)