### PR TITLE
chore: move client out of docker-compose.yml

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,21 +11,27 @@ JAJA (Just Automate Junk Assignments) — a web app for saving D2L (Desire2Learn
 ### Full stack (Docker)
 
 ```bash
-# Start cloudflared tunnel on port 9000 (in a separate terminal)
+# Terminal 1: Start cloudflared tunnel on port 9000
 cloudflared tunnel --url http://localhost:9000
 
-# Then start the full stack
-docker compose up          # Starts db, redis, minio, server, and client with hot reload
+# Terminal 2: Start Docker services (db, redis, minio, server)
+docker compose up
+
+# Terminal 3: Start the frontend
+cd apps/client && bun dev
 ```
 
-- Frontend: http://localhost:3000
+**Service URLs:**
+- Frontend: http://localhost:3000 (from `bun dev` in Terminal 3)
 - Server: http://localhost:4000 (via Docker) or http://localhost:8080 (manual)
 - PostgreSQL: localhost:5432
 - Redis: localhost:6379
 - MinIO API: http://localhost:9000
 - MinIO Console: http://localhost:9001
 
-Note: The cloudflared tunnel URL (from the first command) should be set as `MINIO_PUBLIC_URL` in `apps/server/.env` for presigned URLs that Claude AI can access.
+**Important:** The client must be started separately with `bun dev` after `docker compose up`. Docker only starts the backend services (db, redis, minio, server).
+
+Note: The cloudflared tunnel URL (from Terminal 1) should be set as `MINIO_PUBLIC_URL` in `apps/server/.env` for presigned URLs that Claude AI can access.
 
 ### Frontend only (`apps/client/`)
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,12 @@ JAJA: Just Automate Junk Assignments — a web app for saving D2L (Desire2Learn)
 ## Quick Start (Docker)
 
 ```bash
+# Terminal 1: Start Docker services
 cp .env.example .env
 docker compose up
+
+# Terminal 2: Start the frontend
+cd apps/client && bun dev
 ```
 
 | Service       | URL                   |
@@ -23,6 +27,8 @@ docker compose up
 | Redis         | localhost:6379        |
 | MinIO API     | http://localhost:9000 |
 | MinIO Console | http://localhost:9001 |
+
+**Note:** The frontend must be started separately with `bun dev` in a second terminal. Docker Compose only starts the backend services (db, redis, minio, server).
 
 ## Setup
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,20 +44,6 @@ services:
             - db
             - redis
 
-    client:
-        build:
-            context: ./apps/client
-            dockerfile: dockerfile
-        ports:
-            - '3000:3000'
-        volumes:
-            - ./apps/client:/app
-            - /app/node_modules
-        env_file:
-            - .env
-        depends_on:
-            - server
-
 volumes:
     pgdata:
     minio_data:


### PR DESCRIPTION
## What Changed

The `client` service has been removed from `docker-compose.yml`. The frontend must now be started manually in a separate terminal using `cd apps/client && bun dev`. Both `README.md` and `.claude/CLAUDE.md` have been updated to reflect this two-terminal workflow, clarifying that Docker Compose only manages backend services (db, redis, minio, server).

## Why This Change

Running the frontend inside Docker was likely causing friction during development (e.g., slower hot reload, volume mount issues). Running it directly with `bun dev` provides a faster and more reliable local development experience, while keeping the backend services containerized.

## Test Plan

- [ ] Run `docker compose up` and confirm only backend services start (db, redis, minio, server)
- [ ] Run `cd apps/client && bun dev` in a separate terminal and confirm the frontend starts on http://localhost:3000
- [ ] Verify the frontend can communicate with the server at http://localhost:4000
- [ ] Confirm hot reload works as expected in the frontend

## Steps to Deploy

- [ ] IF DEPLOYING TO MAIN, REBASE FROM MAIN
- [ ] No migrations required
- [ ] No scripts to run
- [ ] Developers must update their local workflow to start the frontend manually outside of Docker

## Type of Change

- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [x] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [x] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed (ghp\_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [x] Updated relevant documentation
- [x] README updated (if needed)