### PR TITLE
feat: mockapi server

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -24,12 +24,15 @@ cd apps/client && bun dev
 **Service URLs:**
 - Frontend: http://localhost:3000 (from `bun dev` in Terminal 3)
 - Server: http://localhost:4000 (via Docker) or http://localhost:8080 (manual)
+- Mock API: http://localhost:4010 (mockapi server, mocks Anthropic API responses)
 - PostgreSQL: localhost:5432
 - Redis: localhost:6379
 - MinIO API: http://localhost:9000
 - MinIO Console: http://localhost:9001
 
-**Important:** The client must be started separately with `bun dev` after `docker compose up`. Docker only starts the backend services (db, redis, minio, server).
+**Important:** The client must be started separately with `bun dev` after `docker compose up`. Docker starts the backend services (db, redis, minio, mock-api, server).
+
+Note: To use the mock API instead of the real Anthropic API, set `ANTHROPIC_API_URL=http://mock-api:4010` in `apps/server/.env` when running via Docker, or `ANTHROPIC_API_URL=http://localhost:4010` when running locally.
 
 Note: The cloudflared tunnel URL (from Terminal 1) should be set as `MINIO_PUBLIC_URL` in `apps/server/.env` for presigned URLs that Claude AI can access.
 
@@ -82,6 +85,45 @@ go run cmd/main.go  # Server includes agent initialization on startup
 
 The agent accepts a prompt (assignment description), processes it with tools (docx generation), and returns the completion result. See `/dev/run-agent` endpoint for usage.
 
+### Mock API server (`apps/server/cmd/mockapi/`)
+
+A standalone Anthropic API mock server for testing without consuming API quota. Runs on port 4010 (in Docker) or configurable via `MOCKAPI_PORT` env var.
+
+**Run mock API server:**
+
+```bash
+# Via Docker (auto-started with docker compose up)
+docker compose up mock-api
+
+# Manual (with Air hot reload)
+cd apps/server
+air -c .air.mockapi.toml
+```
+
+**Add fixtures:**
+
+Fixtures are embedded JSON responses stored in `internal/mockapi/handlers/anthropic/testdata/`. The `analyze_basic.json` fixture is embedded into the binary via `//go:embed` in `provider.go`:
+
+1. Create a new fixture file in `internal/mockapi/handlers/anthropic/testdata/` (e.g., `my_fixture.json`)
+2. Update `provider.go` to embed it and return it from the appropriate handler
+3. Example for `/v1/messages` endpoint: modify `HandleMessages()` to select fixtures based on request parameters
+
+**Add new endpoints:**
+
+1. Create handler function in `internal/mockapi/handlers/anthropic/provider.go` (or new handler file)
+2. Register route in `internal/mockapi/routes/anthropic.go` by adding to `RegisterAnthropicRoutes()`
+3. Example structure:
+   ```go
+   // In provider.go
+   func HandleNewEndpoint(c *gin.Context) {
+       // Return fixture or custom response
+       c.JSON(200, gin.H{"key": "value"})
+   }
+   
+   // In routes/anthropic.go
+   routes.GET("/new-endpoint", anthropic.HandleNewEndpoint)
+   ```
+
 ### Database migrations (Goose)
 
 Migrations live in `apps/server/migrations/` using Goose SQL format. GORM auto-migrates models on startup, but schema changes should also have corresponding Goose migration files. Environment variables for Goose are in the root `.env`.
@@ -99,6 +141,15 @@ apps/
 │   └── utils/string.ts   # parseStringToJSON() for tab-separated cookie/storage data
 └── server/               # Go 1.25 + Gin + GORM + Anthropic SDK + asynq
     ├── cmd/main.go       # Entry point: loads env, connects DB + Redis + S3 + Agent + Workers, sets up router
+    ├── cmd/mockapi/      # Mock Anthropic API server (port 4010)
+    │   └── main.go       # Entry point: Gin router with mock handlers
+    ├── internal/mockapi/ # Mock API implementation
+    │   ├── handlers/
+    │   │   └── anthropic/
+    │   │       ├── provider.go # Handlers: HandleMessages, HandleFileMetadata, HandleFileContent
+    │   │       └── testdata/   # Embedded JSON fixtures (analyze_basic.json)
+    │   └── routes/
+    │       └── anthropic.go # RegisterAnthropicRoutes - routes `/v1/messages`, `/v1/files/:id`, etc.
     ├── agent/            # Claude AI agent via Google ADK + Anthropic SDK
     │   ├── config.go     # ConnectAgent() initializes global AgentRunner
     │   ├── agents/       # Agent definitions
@@ -135,7 +186,9 @@ apps/
     │   │   ├── agent.go  # RunAgent wrapper
     │   │   └── s3.go     # S3 helpers
     │   └── routes/       # Route registration: RegisterD2LRoutes, RegisterDevRoutes
-    └── migrations/       # Goose SQL migration files (includes jobs table schema)
+    ├── migrations/       # Goose SQL migration files (includes jobs table schema)
+    ├── .air.toml         # Air config for main server (hot reload on :8080/4000)
+    └── .air.mockapi.toml # Air config for mock API server (hot reload on :4010)
 ```
 
 ### Key patterns
@@ -147,7 +200,8 @@ apps/
 - **Server → Redis/asynq**: Asynq job queue (`github.com/hibiken/asynq`) for background task processing. Global `config.RedisClient` initialized via `queue.ConnectRedis()` from `REDIS_URL` env var. Separate from the jobs table (DB-backed): DB polls jobs table, dispatches to handlers via asynq workers.
 - **Server → Jobs/Workers**: DB-backed job queue (`internal/models/jobs.go` + `internal/workers/workers.go`). Jobs table tracks status (pending/running/done/failed), type, payload, result. `workers.Server` polls pending jobs, dispatches to handlers in `internal/jobs/handlers/` based on job type (currently JobTypeDocx → HandleDocx).
 - **Server → S3**: AWS SDK Go v2 with MinIO (S3-compatible). Global `config.S3BasicsBucket` (BucketBasics struct) initialized via `storage.ConnectObjectStorage()` with static credentials. Helpers in `internal/storage/s3.go` provide CRUD, multipart uploads/downloads, copy, list, exists, presigned URLs. Connection validates via ListBuckets on startup. Presigned URLs signed with `MINIO_PUBLIC_URL` (external via cloudflared) or `MINIO_URL` (internal).
-- **Server → Claude AI Agent**: Anthropic SDK Go client (`github.com/anthropics/anthropic-sdk-go`) initialized from `ANTHROPIC_API_KEY`. `agent/runner/runner.go` runs the JAJA agent (Google ADK): takes assignment key, fetches from S3, runs LLM agent, generates `.docx` via `agent/tools/docx.go` (using unioffice), uploads result to S3, updates DB job status. `agent/agents/orchestrator.go` defines the agent with system prompt and docx tool. `agent/models/anthropic.go` adapts Anthropic SDK to ADK model interface (tool conversion, system prompts, max tokens).
+- **Server → Claude AI Agent**: Anthropic SDK Go client (`github.com/anthropics/anthropic-sdk-go`) initialized from `ANTHROPIC_API_KEY` and `ANTHROPIC_API_URL` (defaults to `https://api.anthropic.com`). `agent/runner/runner.go` runs the JAJA agent (Google ADK): takes assignment key, fetches from S3, runs LLM agent, generates `.docx` via `agent/tools/docx.go` (using unioffice), uploads result to S3, updates DB job status. `agent/agents/orchestrator.go` defines the agent with system prompt and docx tool. `agent/models/anthropic.go` adapts Anthropic SDK to ADK model interface (tool conversion, system prompts, max tokens). For testing, set `ANTHROPIC_API_URL` to mock API endpoint (e.g., `http://localhost:4010`).
+- **Mock API Server**: Standalone Gin server in `cmd/mockapi/` that mocks Anthropic API responses for testing and development. Runs independently on port 4010 (or `MOCKAPI_PORT` env var). Includes embedded JSON fixtures in `internal/mockapi/handlers/anthropic/testdata/`. Useful for testing agent behavior without consuming API quota or network calls.
 - **CORS**: Server reads `FRONTEND_URL` from env to configure allowed origins.
 - **shadcn/ui**: Uses Radix Lyra style with Phosphor Icons. Config in `components.json`.
 - **Path aliases**: `@/*` maps to project root in TypeScript.
@@ -157,8 +211,10 @@ apps/
 - Root `.env`: Used by docker-compose services
     - `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` — PostgreSQL credentials
     - `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD` — MinIO S3 credentials
-- `apps/server/.env`: Used by Gin server
+- `apps/server/.env`: Used by Gin server and mock API
     - `PORT` — Server port (default 8080 for manual, Docker exposes 4000)
+    - `MOCKAPI_PORT` — Mock API port (default 4010, used by docker-compose)
+    - `ANTHROPIC_API_URL` — Anthropic API endpoint (default `https://api.anthropic.com`, set to `http://mock-api:4010` or `http://localhost:4010` to use mock server)
     - `FRONTEND_URL` — Client origin for CORS (e.g., http://localhost:3000)
     - `DB_URL` — PostgreSQL DSN (e.g., postgres://user:pass@db:5432/jaja)
     - `REDIS_URL` — Redis endpoint (e.g., redis:6379 in Docker, localhost:6379 for manual runs). **Required** — server fatally exits on startup if unset.

--- a/apps/server/.air.mockapi.toml
+++ b/apps/server/.air.mockapi.toml
@@ -1,0 +1,37 @@
+#:schema https://json.schemastore.org/any.json
+
+env_files = []
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  bin = "./tmp/mockapi"
+  cmd = "go build -o ./tmp/mockapi ./cmd/mockapi"
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_regex = ["_test.go"]
+  include_ext = ["go", "json"]
+  log = "build-errors.log"
+  poll = true
+  poll_interval = 500
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  silent = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/apps/server/cmd/mockapi/main.go
+++ b/apps/server/cmd/mockapi/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"os"
+
+	"server/internal/mockapi/routes"
+
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	router := gin.Default()
+
+	api := router.Group("/")
+	{
+		routes.RegisterAnthropicRoutes(api)
+	}
+
+	router.Run(":" + os.Getenv("MOCKAPI_PORT"))
+}

--- a/apps/server/internal/mockapi/README.md
+++ b/apps/server/internal/mockapi/README.md
@@ -1,0 +1,195 @@
+# Mock Anthropic API Server
+
+A standalone mock server for testing JAJA without consuming Anthropic API quota. Simulates the Anthropic API with embedded JSON fixtures.
+
+## Quick Start
+
+### Via Docker
+
+```bash
+docker compose up mock-api
+```
+
+Runs on http://localhost:4010 (configured via `MOCKAPI_PORT=4010` in docker-compose.yml).
+
+### Manual with Air (hot reload)
+
+```bash
+cd apps/server
+air -c .air.mockapi.toml
+```
+
+Runs on the port specified by `MOCKAPI_PORT` env var (default 4010).
+
+## Configuration
+
+Set these environment variables in `apps/server/.env`:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `MOCKAPI_PORT` | `4010` | Port the mock server listens on |
+| `ANTHROPIC_API_URL` | `https://api.anthropic.com` | Set this on the **main server** to point at mock-api (e.g., `http://mock-api:4010` in Docker, `http://localhost:4010` locally) |
+
+**Point the main server at mock-api:**
+
+In `apps/server/.env`:
+
+```bash
+ANTHROPIC_API_URL=http://localhost:4010      # For manual testing
+ANTHROPIC_API_URL=http://mock-api:4010       # For Docker
+```
+
+## Available Endpoints
+
+All routes are prefixed with `/v1` (matching Anthropic API versioning).
+
+| Method | Path | Status | Handler |
+| --- | --- | --- | --- |
+| `POST` | `/v1/messages` | ✅ Working | Returns embedded JSON fixture (`analyze_basic.json`) |
+| `GET` | `/v1/files/:id` | ⚠️ Stub | Returns 404 (file metadata endpoint) |
+| `GET` | `/v1/files/:id/content` | ⚠️ Stub | Returns 404 (file content endpoint) |
+
+## Fixtures
+
+Fixtures are JSON responses embedded into the binary at build time using Go's `//go:embed` directive. They live in `handlers/anthropic/testdata/`.
+
+### Current Fixtures
+
+- **`analyze_basic.json`** — Response for `/v1/messages`, simulates Claude analyzing an assignment
+
+### Fixture Format
+
+Fixtures are valid Anthropic API response JSONs. Example structure:
+
+```json
+{
+  "id": "msg_01TestFixture",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-haiku-4-5-20251001",
+  "content": [
+    {
+      "type": "text",
+      "text": "Analysis of the assignment..."
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 150,
+    "output_tokens": 200
+  }
+}
+```
+
+## How to Add a Fixture
+
+1. Create a new JSON file in `handlers/anthropic/testdata/` (e.g., `my_fixture.json`)
+
+2. Update `handlers/anthropic/provider.go` to embed and use it:
+
+```go
+import _ "embed"
+
+// TODO: make this configurable based on request content
+//go:embed testdata/my_fixture.json
+var myFixture []byte
+
+func HandleMessages(c *gin.Context) {
+    response := map[string]any{}
+    err := json.Unmarshal(myFixture, &response)
+    if err != nil {
+        c.JSON(500, gin.H{"error": err.Error()})
+        return
+    }
+    c.JSON(200, response)
+}
+```
+
+3. Rebuild the binary (Air auto-rebuilds when you save Go files if using manual mode)
+
+4. Test:
+```bash
+curl -X POST http://localhost:4010/v1/messages \
+  -H "Content-Type: application/json" \
+  -d '{"model": "claude-3-5-sonnet-20241022", "max_tokens": 1000, "messages": []}'
+```
+
+## How to Add an Endpoint
+
+1. Create a handler function in `handlers/anthropic/provider.go`:
+
+```go
+func HandleNewEndpoint(c *gin.Context) {
+    // Return a fixture, custom response, or error
+    c.JSON(200, gin.H{
+        "key": "value",
+        "status": "ok",
+    })
+}
+```
+
+2. Register the route in `routes/anthropic.go`:
+
+```go
+func RegisterAnthropicRoutes(rg *gin.RouterGroup) {
+    routes := rg.Group("/v1")
+    {
+        routes.POST("/messages", anthropic.HandleMessages)
+        routes.GET("/new-endpoint", anthropic.HandleNewEndpoint)  // Add this line
+    }
+}
+```
+
+3. Rebuild and test:
+
+```bash
+curl http://localhost:4010/v1/new-endpoint
+```
+
+## Testing with the Main Server
+
+Once the mock server is running, the main JAJA server will use it for all Anthropic API calls. This allows you to:
+
+- **Test agent workflows** without API quota costs
+- **Test with deterministic responses** (same fixture every time)
+- **Iterate quickly** on agent logic without network latency
+- **Develop offline** if Anthropic API is unavailable
+
+Example: Run the agent with mock responses:
+
+```bash
+# Terminal 1: Start mock-api
+cd apps/server && air -c .air.mockapi.toml
+
+# Terminal 2: Start main server (will use mock-api)
+cd apps/server && go run cmd/main.go
+
+# Terminal 3: Run the agent
+curl -X POST http://localhost:8080/dev/run-agent \
+  -H "Content-Type: application/json" \
+  -d '{"session_id": "test", "user_id": "user-1", "assignment_key": "assignment-1"}'
+```
+
+## Limitations & TODOs
+
+- File endpoints (`/v1/files/:id`, `/v1/files/:id/content`) currently return 404 stubs
+- Fixtures are static — no dynamic request-based response selection yet
+- No support for streaming responses or tool use yet
+- Consider making fixture selection conditional on request content (e.g., based on prompt parameters)
+
+## Architecture
+
+```
+mockapi/
+├── cmd/mockapi/main.go          # Entry point: creates Gin router, registers routes
+├── internal/mockapi/
+│   ├── routes/
+│   │   └── anthropic.go          # Route registration: POST /v1/messages, GET /v1/files/:id
+│   └── handlers/
+│       └── anthropic/
+│           ├── provider.go       # Handler functions: HandleMessages, HandleFileMetadata, HandleFileContent
+│           └── testdata/         # Embedded JSON fixtures
+│               └── analyze_basic.json
+└── .air.mockapi.toml            # Air config for hot reload
+```

--- a/apps/server/internal/mockapi/handlers/anthropic/provider.go
+++ b/apps/server/internal/mockapi/handlers/anthropic/provider.go
@@ -1,0 +1,33 @@
+package anthropic
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TODO: this is a temporary fixture for the messages endpoint.
+//go:embed testdata/analyze_basic.json
+var messagesFixture []byte
+
+// TODO: add proper file metadata and content endpoints
+func HandleMessages(c *gin.Context) {
+	response := map[string]any{}
+	err := json.Unmarshal(messagesFixture, &response)
+	if err != nil {
+		fmt.Println("error unmarshalling messages fixture: ", err)
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(200, response)
+}
+
+func HandleFileMetadata(c *gin.Context) {
+	c.JSON(404, gin.H{"error": "file not found: " + c.Param("id")})
+}
+
+func HandleFileContent(c *gin.Context) {
+	c.JSON(404, gin.H{"error": "file not found: " + c.Param("id")})
+}

--- a/apps/server/internal/mockapi/handlers/anthropic/testdata/analyze_basic.json
+++ b/apps/server/internal/mockapi/handlers/anthropic/testdata/analyze_basic.json
@@ -1,0 +1,18 @@
+{
+    "id": "msg_01TestFixtureAnalyzeBasic",
+    "type": "message",
+    "role": "assistant",
+    "model": "claude-haiku-4-5-20251001",
+    "content": [
+        {
+            "type": "text",
+            "text": "ASSIGNMENT ANALYSIS\n\n1. Assignment type: Analytical essay\n2. Requirements: Five-page critical analysis of the provided text, with a clear thesis and supporting evidence drawn from the source material.\n3. Key topics: Close reading, thematic analysis, textual evidence.\n4. Length: Approximately 1500 words.\n5. Formatting: MLA citation style, 12pt Times New Roman, double-spaced, 1-inch margins.\n6. Rubric: Thesis clarity (25%), use of evidence (30%), organization (20%), mechanics (25%).\n7. Other constraints: No outside sources permitted; analysis must be drawn entirely from the provided text."
+        }
+    ],
+    "stop_reason": "end_turn",
+    "stop_sequence": null,
+    "usage": {
+        "input_tokens": 150,
+        "output_tokens": 200
+    }
+}

--- a/apps/server/internal/mockapi/routes/anthropic.go
+++ b/apps/server/internal/mockapi/routes/anthropic.go
@@ -1,0 +1,16 @@
+package routes
+
+import (
+	"server/internal/mockapi/handlers/anthropic"
+
+	"github.com/gin-gonic/gin"
+)
+
+func RegisterAnthropicRoutes(rg *gin.RouterGroup) {
+	routes := rg.Group("/v1")
+	{
+		routes.POST("/messages", anthropic.HandleMessages)
+		routes.GET("/files/:id", anthropic.HandleFileMetadata)
+		routes.GET("/files/:id/content", anthropic.HandleFileContent)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,10 +30,21 @@ services:
         volumes:
             - redis_data:/data
 
-    server:
+    mock-api:
+        image: jaja-server
         build:
             context: ./apps/server
             dockerfile: dockerfile
+        ports:
+            - '4010:4010'
+        environment:
+            MOCKAPI_PORT: '4010'
+        volumes:
+            - ./apps/server:/app
+        command: ["air", "-c", ".air.mockapi.toml"]
+
+    server:
+        image: jaja-server
         ports:
             - '4000:4000'
         volumes:
@@ -43,6 +54,7 @@ services:
         depends_on:
             - db
             - redis
+            - mock-api
 
 volumes:
     pgdata:


### PR DESCRIPTION
## What Changed

Introduces a mock Anthropic API server (`mockapi`) that can be run locally as a standalone service. Currently, the mock server exposes `/v1/messages`, `/v1/files/:id`, and `/v1/files/:id/content` endpoints, with the messages endpoint returning a hardcoded fixture response (`analyze_basic.json`) representing a basic assignment analysis. File metadata and content endpoints return 404 stubs. A dedicated Air hot-reload config (`.air.mockapi.toml`) is included for development. The `mock-api` service is added to `docker-compose.yml` and the `server` service is configured to depend on it.

## Why This Change

Provides a local stand-in for the Anthropic API so that development and testing can proceed without making real API calls or incurring costs. This allows the server to be exercised end-to-end in a controlled environment with predictable, fixture-driven responses.

## Test Plan

- [x] Run `docker compose up mock-api` and confirm the service starts on port `4010`
- [x] Send a `POST /v1/messages` request to `http://localhost:4010` in postman and verify the fixture response is returned

## Steps to Deploy

- [x] Ensure `MOCKAPI_PORT` environment variable is set (defaults to `4010` in docker-compose)